### PR TITLE
READMEのinstallのバージョン追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ gqlfmt has two issues. https://github.com/gqlgo/gqlfmt/issues/1 and https://gith
 ## Install
 
 ```
-go install github.com/gqlgo/gqlfmt
+go install github.com/gqlgo/gqlfmt@latest
 ```
 
 ## Usage


### PR DESCRIPTION
`go install`にはバージョン指定が必須だったため追加しました。